### PR TITLE
Fix Warning errors in docs build ("#2989)

### DIFF
--- a/Untitled16.ipynb
+++ b/Untitled16.ipynb
@@ -1,0 +1,195 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "!rm -rf docs\n",
+        "!sphinx-quickstart docs -q -p \"Deepchem Docs\" -a \"Deepchem team\" --sep -v 0.1 --ext-autodoc --ext-viewcode --ext-todo"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "yzMCWMUUEsKy",
+        "outputId": "9926a98e-b2dd-4208-b85b-8c1179e8ed7a"
+      },
+      "execution_count": 34,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "\u001b[01mFinished: An initial directory structure has been created.\u001b[39;49;00m\n",
+            "\n",
+            "You should now populate your master file /content/deepchem/deepchem/docs/source/index.rst and create other documentation\n",
+            "source files. Use the Makefile to build the docs, like so:\n",
+            "   make builder\n",
+            "where \"builder\" is one of the supported builders, e.g. html, latex or linkcheck.\n",
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%%writefile 'docs/source/introduction.rst'\n",
+        "Welcome to Deepchems documentation!\n",
+        "----------------------------------\n",
+        "This page helps you understand **common errors** faced by users and how to fix them.\n",
+        "Contents:\n",
+        "   **ImportError**\n",
+        "   - **problem**: cannot import 'deepchem'\n",
+        "    -**Fix**:Run 'pip install deepchem'\n",
+        "   **TensorFlow version mismatch**\n",
+        "    - **problem**: Deepchem not working with curret TensorFlow\n",
+        "    - **Fix**: Install supported version:'pip install tensorflow==2.10.0'\n",
+        "   **missing dependencies**\n",
+        "    - **problem**:ModuleNotFoundError for 'rdkit','sklearn'\n",
+        "    - **Fix**: Install: 'pip install rdkit scikit-learn'\n",
+        "\n",
+        "\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Y6cHGKls-VRM",
+        "outputId": "c561417a-3904-417c-ffc4-3aafd1c46ba8"
+      },
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Writing docs/source/introduction.rst\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%%writefile docs/source/index.rst\n",
+        "Welcome to Deepchem Docs!\n",
+        "----------------------------------------------------------\n",
+        " ..toctree::\n",
+        "  :maxdepth: 2\n",
+        "  :caption: Contents:\n",
+        "\n",
+        "  introduction"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "fJHKUlRWU9SV",
+        "outputId": "b870d8f7-b060-4853-9c61-222030393f60"
+      },
+      "execution_count": 37,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Overwriting docs/source/index.rst\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!sphinx-build docs/source docs/build"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "1O28MzrOV7Es",
+        "outputId": "833b5169-3540-4063-9459-89b2f140b654"
+      },
+      "execution_count": 38,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[01mRunning Sphinx v7.2.6\u001b[39;49;00m\n",
+            "\u001b[01mbuilding [mo]: \u001b[39;49;00mtargets for 0 po files that are out of date\n",
+            "\u001b[01mwriting output... \u001b[39;49;00m\n",
+            "\u001b[01mbuilding [html]: \u001b[39;49;00mtargets for 1 source files that are out of date\n",
+            "\u001b[01mupdating environment: \u001b[39;49;00m[new config] 1 added, 0 changed, 0 removed\n",
+            "\u001b[2K\u001b[01mreading sources... \u001b[39;49;00m[100%] \u001b[35mindex\u001b[39;49;00m\n",
+            "\u001b[01mlooking for now-outdated files... \u001b[39;49;00mnone found\n",
+            "\u001b[01mpickling environment... \u001b[39;49;00mdone\n",
+            "\u001b[01mchecking consistency... \u001b[39;49;00mdone\n",
+            "\u001b[01mpreparing documents... \u001b[39;49;00mdone\n",
+            "\u001b[01mcopying assets... \u001b[39;49;00m\u001b[01mcopying static files... \u001b[39;49;00mdone\n",
+            "\u001b[01mcopying extra files... \u001b[39;49;00mdone\n",
+            "done\n",
+            "\u001b[2K\u001b[01mwriting output... \u001b[39;49;00m[100%] \u001b[32mindex\u001b[39;49;00m\n",
+            "\u001b[01mgenerating indices... \u001b[39;49;00mgenindex done\n",
+            "\u001b[01mhighlighting module code... \u001b[39;49;00m\n",
+            "\u001b[01mwriting additional pages... \u001b[39;49;00msearch done\n",
+            "\u001b[01mdumping search index in English (code: en)... \u001b[39;49;00mdone\n",
+            "\u001b[01mdumping object inventory... \u001b[39;49;00mdone\n",
+            "\u001b[01mbuild succeeded.\u001b[39;49;00m\n",
+            "\n",
+            "The HTML pages are in docs/build.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!sphinx-build docs/source docs/build"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "n99Z_dS1Wylu",
+        "outputId": "a4b86488-8092-4597-8e54-81a94508d8e2"
+      },
+      "execution_count": 39,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[01mRunning Sphinx v7.2.6\u001b[39;49;00m\n",
+            "\u001b[01mloading pickled environment... \u001b[39;49;00mdone\n",
+            "\u001b[01mbuilding [mo]: \u001b[39;49;00mtargets for 0 po files that are out of date\n",
+            "\u001b[01mwriting output... \u001b[39;49;00m\n",
+            "\u001b[01mbuilding [html]: \u001b[39;49;00mtargets for 0 source files that are out of date\n",
+            "\u001b[01mupdating environment: \u001b[39;49;00m0 added, 0 changed, 0 removed\n",
+            "\u001b[01mreading sources... \u001b[39;49;00m\n",
+            "\u001b[01mlooking for now-outdated files... \u001b[39;49;00mnone found\n",
+            "\u001b[01mno targets are out of date.\u001b[39;49;00m\n",
+            "\u001b[01mbuild succeeded.\u001b[39;49;00m\n",
+            "\n",
+            "The HTML pages are in docs/build.\n"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request fixes the documentaion build warnings mentioned in issue#2989. The changes include updating or removing deprecated or incorrect doc elements to ensure the documentation builds cleanly without warnings.