### PR TITLE
 Add readme .md for Create Meta-Learner - Fixex #905

### DIFF
--- a/905-meta-learner
+++ b/905-meta-learner
@@ -1,0 +1,11 @@
+# M etaLearner - Deepchem
+This module was added as a fix for [issue #905] (https://github.com/deepchem/deepchem/issues/905) in deepchem.
+## File: 'meta_learn.py'
+### Description
+Introduced a basic 'MetaLearner' class
+Contains:
+- '__init__()' for model configuration
+'train()'for training logic (to be extended)
+Ptedict()' for inference (to be extended)
+### Contribution
+Created by [Likhitha Narayana] as part of Gsoc 2025 application.


### PR DESCRIPTION
This  PR introduces a new file 'meta_learn.py' under 'DeepChem/models/TensorFlow_models/Meta_learn/',
which contains a basic 'MetaLearner' class structured as part of the fix for issue #905.

Also added a 'readme.md' inside the 'meta_learn' folder explaining the functionality, purpose,and future extensibility of the 'MetaLearner'.
These changes are designed to lay the foundation for meta-learning support in Deepchem and follow the contribution guidelines.
This is part of my preparation for Gsoc 2025 and intended to be helpful for new contributors who want to explore the meta-learning section in DeepChem